### PR TITLE
YB: workaround to fix 004_pg_dump_parallel.pl test

### DIFF
--- a/src/bin/pg_dump/t/004_pg_dump_parallel.pl
+++ b/src/bin/pg_dump/t/004_pg_dump_parallel.pl
@@ -49,6 +49,7 @@ insert into tht select (x%10)::text::digit, x from generate_series(1,1000) x;
 $node->command_ok(
 	[
 		'pg_dump', '-Fd', '--no-sync', '-j2', '-f', "$backupdir/dump1",
+		'--load-via-partition-root',
 		$node->connstr($dbname1)
 	],
 	'parallel dump');
@@ -66,6 +67,7 @@ $node->command_ok(
 		'pg_dump',   '-Fd',
 		'--no-sync', '-j2',
 		'-f',        "$backupdir/dump2",
+		'--load-via-partition-root',
 		'--inserts', $node->connstr($dbname1)
 	],
 	'parallel dump as inserts');


### PR DESCRIPTION
Test 004_pg_dump_parallel.pl was introduced by commit 2b216da1e55dc125ada193328e87e471d49b0938, which states that it teaches pg_dump to apply load-via-partition-root automatically when detecting hash-on-enum partitioning.  For some reason, importing commit 96a81c1be929d122719bd289f6e24824f37e1ff6 causes this detection to stop working.  This causes the test to fail.

Given YB backup/restore usually uses --include-yb-metadata which causes enum oids and sort orders to be preserved, YB doesn't really need load-via-partition-root nor the automatic detection.  Therefore, ignore the failing auto detection for now and just fix the test by manually passing --load-via-partition-root to pg_dump.  In the future, this issue will naturally go away as YB merges to future versions beyond 96a81c1be929d122719bd289f6e24824f37e1ff6.  At that point, this test change should be discarded.