### PR TITLE
pgcrypto: Import FIPS mode support from upstream (924d89a, 035f99c)

### DIFF
--- a/contrib/pgcrypto/Makefile
+++ b/contrib/pgcrypto/Makefile
@@ -36,7 +36,7 @@ MODULE_big	= pgcrypto
 
 EXTENSION = pgcrypto
 DATA = pgcrypto--1.3.sql pgcrypto--1.2--1.3.sql pgcrypto--1.1--1.2.sql \
-	pgcrypto--1.0--1.1.sql
+	pgcrypto--1.0--1.1.sql pgcrypto--1.3--1.4.sql
 PGFILEDESC = "pgcrypto - cryptographic functions"
 
 REGRESS = init md5 sha1 hmac-md5 hmac-sha1 blowfish rijndael \

--- a/contrib/pgcrypto/expected/crypt-des.out
+++ b/contrib/pgcrypto/expected/crypt-des.out
@@ -28,4 +28,11 @@ FROM ctest;
  t
 (1 row)
 
+-- check disabling of built in crypto functions
+SET pgcrypto.builtin_crypto_enabled = off;
+UPDATE ctest SET salt = gen_salt('des');
+ERROR:  use of built-in crypto functions is disabled
+UPDATE ctest SET res = crypt(data, salt);
+ERROR:  use of built-in crypto functions is disabled
+RESET pgcrypto.builtin_crypto_enabled;
 DROP TABLE ctest;

--- a/contrib/pgcrypto/openssl.c
+++ b/contrib/pgcrypto/openssl.c
@@ -827,3 +827,30 @@ px_find_cipher(const char *name, PX_Cipher **res)
 	*res = c;
 	return 0;
 }
+
+/*
+ * CheckFIPSMode
+ *
+ * Returns the FIPS mode of the underlying OpenSSL installation.
+ */
+bool
+CheckFIPSMode(void)
+{
+	int			fips_enabled = 0;
+
+	/*
+	 * EVP_default_properties_is_fips_enabled was added in OpenSSL 3.0, before
+	 * that FIPS_mode() was used to test for FIPS being enabled.  The last
+	 * upstream OpenSSL version before 3.0 which supported FIPS was 1.0.2, but
+	 * there are forks of 1.1.1 which are FIPS validated so we still need to
+	 * test with FIPS_mode() even though we don't support 1.0.2.
+	 */
+	fips_enabled =
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+		EVP_default_properties_is_fips_enabled(NULL);
+#else
+		FIPS_mode();
+#endif
+
+	return (fips_enabled == 1);
+}

--- a/contrib/pgcrypto/openssl.c
+++ b/contrib/pgcrypto/openssl.c
@@ -31,6 +31,7 @@
 
 #include "postgres.h"
 
+#include <openssl/crypto.h>
 #include <openssl/evp.h>
 #include <openssl/err.h>
 #include <openssl/rand.h>
@@ -853,4 +854,29 @@ CheckFIPSMode(void)
 #endif
 
 	return (fips_enabled == 1);
+}
+
+/*
+ * CheckBuiltinCryptoMode
+ *
+ * Function for erroring out in case built-in crypto is executed when the user
+ * has disabled it. If builtin_crypto_enabled is set to BC_OFF or BC_FIPS and
+ * OpenSSL is operating in FIPS mode the function will error out, else the
+ * query executing built-in crypto can proceed.
+ */
+void
+CheckBuiltinCryptoMode(void)
+{
+	if (builtin_crypto_enabled == BC_ON)
+		return;
+
+	if (builtin_crypto_enabled == BC_OFF)
+		ereport(ERROR,
+				errmsg("use of built-in crypto functions is disabled"));
+
+	Assert(builtin_crypto_enabled == BC_FIPS);
+
+	if (CheckFIPSMode() == true)
+		ereport(ERROR,
+				errmsg("use of non-FIPS validated crypto not allowed when OpenSSL is in FIPS mode"));
 }

--- a/contrib/pgcrypto/pgcrypto--1.3--1.4.sql
+++ b/contrib/pgcrypto/pgcrypto--1.3--1.4.sql
@@ -1,0 +1,9 @@
+/* contrib/pgcrypto/pgcrypto--1.3--1.4.sql */
+
+-- complain if script is sourced in psql, rather than via ALTER EXTENSION
+\echo Use "ALTER EXTENSION pgcrypto UPDATE TO '1.4'" to load this file. \quit
+
+CREATE FUNCTION fips_mode()
+RETURNS bool
+AS 'MODULE_PATHNAME', 'pg_check_fipsmode'
+LANGUAGE C VOLATILE STRICT PARALLEL SAFE;

--- a/contrib/pgcrypto/pgcrypto.c
+++ b/contrib/pgcrypto/pgcrypto.c
@@ -38,14 +38,47 @@
 #include "px-crypt.h"
 #include "px.h"
 #include "utils/builtins.h"
+#include "utils/guc.h"
 #include "utils/uuid.h"
 
 PG_MODULE_MAGIC;
 
+void _PG_init(void);
+
 /* private stuff */
+
+static const struct config_enum_entry builtin_crypto_options[] = {
+	{"on", BC_ON, false},
+	{"off", BC_OFF, false},
+	{"fips", BC_FIPS, false},
+	{NULL, 0, false}
+};
 
 typedef int (*PFN) (const char *name, void **res);
 static void *find_provider(text *name, PFN pf, const char *desc, int silent);
+
+int			builtin_crypto_enabled = BC_ON;
+
+/*
+ * Entrypoint of this module.
+ */
+void
+_PG_init(void)
+{
+	DefineCustomEnumVariable("pgcrypto.builtin_crypto_enabled",
+							 "Sets if builtin crypto functions are enabled.",
+							 "\"on\" enables builtin crypto, \"off\" unconditionally disables and \"fips\" "
+							 "will disable builtin crypto if OpenSSL is in FIPS mode",
+							 &builtin_crypto_enabled,
+							 BC_ON,
+							 builtin_crypto_options,
+							 PGC_SUSET,
+							 0,
+							 NULL,
+							 NULL,
+							 NULL);
+	MarkGUCPrefixReserved("pgcrypto");
+}
 
 /* SQL function: hash(bytea, text) returns bytea */
 PG_FUNCTION_INFO_V1(pg_digest);

--- a/contrib/pgcrypto/pgcrypto.c
+++ b/contrib/pgcrypto/pgcrypto.c
@@ -449,6 +449,14 @@ pg_random_uuid(PG_FUNCTION_ARGS)
 	return gen_random_uuid(fcinfo);
 }
 
+PG_FUNCTION_INFO_V1(pg_check_fipsmode);
+
+Datum
+pg_check_fipsmode(PG_FUNCTION_ARGS)
+{
+	PG_RETURN_BOOL(CheckFIPSMode());
+}
+
 static void *
 find_provider(text *name,
 			  PFN provider_lookup,

--- a/contrib/pgcrypto/pgcrypto.control
+++ b/contrib/pgcrypto/pgcrypto.control
@@ -1,6 +1,6 @@
 # pgcrypto extension
 comment = 'cryptographic functions'
-default_version = '1.3'
+default_version = '1.4'
 module_pathname = '$libdir/pgcrypto'
 relocatable = true
 trusted = true

--- a/contrib/pgcrypto/px-crypt.c
+++ b/contrib/pgcrypto/px-crypt.c
@@ -91,6 +91,8 @@ px_crypt(const char *psw, const char *salt, char *buf, unsigned len)
 {
 	const struct px_crypt_algo *c;
 
+	CheckBuiltinCryptoMode();
+
 	for (c = px_crypt_list; c->id; c++)
 	{
 		if (!c->id_len)
@@ -134,6 +136,8 @@ px_gen_salt(const char *salt_type, char *buf, int rounds)
 	struct generator *g;
 	char	   *p;
 	char		rbuf[16];
+
+	CheckBuiltinCryptoMode();
 
 	for (g = gen_list; g->name; g++)
 		if (pg_strcasecmp(g->name, salt_type) == 0)

--- a/contrib/pgcrypto/px.h
+++ b/contrib/pgcrypto/px.h
@@ -182,6 +182,8 @@ void		px_set_debug_handler(void (*handler) (const char *));
 
 void		px_memset(void *ptr, int c, size_t len);
 
+bool		CheckFIPSMode(void);
+
 #ifdef PX_DEBUG
 void		px_debug(const char *fmt,...) pg_attribute_printf(1, 2);
 #else

--- a/contrib/pgcrypto/px.h
+++ b/contrib/pgcrypto/px.h
@@ -89,12 +89,20 @@
 #define PXE_PGP_UNSUPPORTED_PUBALGO -122
 #define PXE_PGP_MULTIPLE_SUBKEYS	-123
 
+typedef enum BuiltinCryptoOptions
+{
+	BC_ON,
+	BC_OFF,
+	BC_FIPS,
+}			BuiltinCryptoOptions;
 
 typedef struct px_digest PX_MD;
 typedef struct px_alias PX_Alias;
 typedef struct px_hmac PX_HMAC;
 typedef struct px_cipher PX_Cipher;
 typedef struct px_combo PX_Combo;
+
+extern int	builtin_crypto_enabled;
 
 struct px_digest
 {
@@ -183,6 +191,7 @@ void		px_set_debug_handler(void (*handler) (const char *));
 void		px_memset(void *ptr, int c, size_t len);
 
 bool		CheckFIPSMode(void);
+void		CheckBuiltinCryptoMode(void);
 
 #ifdef PX_DEBUG
 void		px_debug(const char *fmt,...) pg_attribute_printf(1, 2);

--- a/contrib/pgcrypto/sql/crypt-des.sql
+++ b/contrib/pgcrypto/sql/crypt-des.sql
@@ -18,4 +18,10 @@ UPDATE ctest SET res = crypt(data, salt);
 SELECT res = crypt(data, res) AS "worked"
 FROM ctest;
 
+-- check disabling of built in crypto functions
+SET pgcrypto.builtin_crypto_enabled = off;
+UPDATE ctest SET salt = gen_salt('des');
+UPDATE ctest SET res = crypt(data, salt);
+RESET pgcrypto.builtin_crypto_enabled;
+
 DROP TABLE ctest;

--- a/doc/src/sgml/pgcrypto.sgml
+++ b/doc/src/sgml/pgcrypto.sgml
@@ -1165,6 +1165,44 @@ fips_mode() returns boolean
   </para>
  </sect2>
 
+ <sect2 id="pgcrypto-configuration-parameters">
+  <title>Configuration Parameters</title>
+
+ <para>
+  There is one configuration parameter that controls the behavior of
+  <filename>pgcrypto</filename>.
+ </para>
+
+  <variablelist>
+   <varlistentry id="pgcrypto-configuration-parameters-builtin_crypto_enabled">
+    <term>
+     <varname>pgcrypto.builtin_crypto_enabled</varname> (<type>enum</type>)
+     <indexterm>
+      <primary><varname>pgcrypto.builtin_crypto_enabled</varname> configuration
+      parameter</primary>
+     </indexterm>
+    </term>
+    <listitem>
+     <para>
+      <varname>pgcrypto.builtin_crypto_enabled</varname> determines if the
+      built in crypto functions <function>gen_salt()</function>, and
+      <function>crypt()</function> are available for use. Setting this to
+      <literal>off</literal> disables these functions. <literal>on</literal>
+      (the default) enables these functions to work normally.
+      <literal>fips</literal> disables these functions if
+      <productname>OpenSSL</productname> is detected to operate in FIPS mode.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+
+  <para>
+   In ordinary usage, this parameter is set
+   in <filename>postgresql.conf</filename>, although superusers can alter it
+   on-the-fly within their own sessions.
+  </para>
+ </sect2>
+
  <sect2>
   <title>Notes</title>
 

--- a/doc/src/sgml/pgcrypto.sgml
+++ b/doc/src/sgml/pgcrypto.sgml
@@ -1149,6 +1149,22 @@ gen_random_uuid() returns uuid
   </para>
  </sect2>
 
+ <sect2 id="pgcrypto-openssl-support-funcs">
+  <title>OpenSSL Support Functions</title>
+
+  <indexterm>
+   <primary>fips_mode</primary>
+  </indexterm>
+
+<synopsis>
+fips_mode() returns boolean
+</synopsis>
+  <para>
+   Returns <literal>true</literal> if <productname>OpenSSL</productname> is
+   running with FIPS mode enabled, otherwise <literal>false</literal>.
+  </para>
+ </sect2>
+
  <sect2>
   <title>Notes</title>
 


### PR DESCRIPTION
This PR cherry-picks 2 upstream commits: https://github.com/postgres/postgres/commit/924d89a & https://github.com/postgres/postgres/commit/035f99c

## Conflict Resolution for 924d89a:

### 1. `contrib/pgcrypto/meson.build`

**Conflict reason:** Upstream's hunk added `'pgcrypto--1.3--1.4.sql',` to `meson.build`. The meson build system was added to PostgreSQL in PG16 by [`e6927270cd`](https://github.com/postgres/postgres/commit/e6927270cd), so `yb-pg15` has no `meson.build` at all, upstream modified a file that doesn't exist on our side.

**Resolution:** Removed `contrib/pgcrypto/meson.build`, preserving the deletion side and dropping the upstream changes.

### 2. `contrib/pgcrypto/openssl.c` (content)

**Conflict reason:** Upstream's hunk appends `CheckFIPSMode()` after the function `ResOwnerReleaseOSSLCipher` at line 794 of upstream `openssl.c`. That function was introduced in PG17 by [`cd694f60dc97`](https://github.com/postgres/postgres/commit/cd694f60dc97) as part of pgcrypto's switch to ResourceOwner-managed contexts. PG15 has none of that, its `openssl.c` is 829 lines and ends with `gen_ossl_encrypt` machinery, the `ResOwnerReleaseOSSLCipher` anchor doesn't exist.

**Resolution:** Appended `CheckFIPSMode()` at the end of `openssl.c`. The upstream anchor doesn't exist on PG15, so placed the hunk positionally at end-of-file. The hunk is purely additive and applied unchanged.

### 3. `doc/src/sgml/pgcrypto.sgml` (content)

**Conflict reason:** Upstream's hunk inserts a new `<sect2 id="pgcrypto-openssl-support-funcs">` block immediately before the Notes section. The hunk's trailing context is `<sect2 id="pgcrypto-notes">`. On PG15 the corresponding line is bare `<sect2>` i.e no `id` attribute. The `id="pgcrypto-notes"` was added by a separate cosmetic docs commit in PG16, [`78ee60ed84bb`](https://github.com/postgres/postgres/commit/78ee60ed84bb) ("Doc: add XML ID attributes to `<sectN>` and `<varlistentry>` tags."), which is not part of `924d89a`. So the context mismatched on that one attribute and Git wrote conflict markers.

**Resolution:**
1. Inserted the new section verbatim from the upstream patch, placed between the `gen_random_uuid` block and the existing `<sect2><title>Notes</title>`.
2. Did not apply the `<sect2>` → `<sect2 id="pgcrypto-notes">` rename. That's an unrelated upstream change that crept into this patch's context — importing it would have been scope creep. Left the Notes section's opening tag as plain `<sect2>`.

## Conflict Resolution for 035f99c:

### 1. `contrib/pgcrypto/pgcrypto.c` (content)

**Conflict reason:** Context drift caused by three upstream commits absent from PG15, all touching lines in the patch's anchor region:
- [`d952373a987b`](https://github.com/postgres/postgres/commit/d952373a987b) ("New header varatt.h split off from postgres.h", PG16) added the `varatt.h` include, upstream's patch context expects it; PG15 has no such header.
- [`9be4e5d293b5`](https://github.com/postgres/postgres/commit/9be4e5d293b5) ("Remove unused #include's from contrib, pl, test .c files", PG18) removed `utils/uuid.h` — upstream's patch context lacks it; PG15 still has it.
- [`0faf7d933f62`](https://github.com/postgres/postgres/commit/0faf7d933f62) ("Harmonize parameter names in contrib code.", PG16) renamed the `find_provider` forward-decl parameter `pf` → `provider_lookup` and reflowed it onto two lines — upstream's patch uses the renamed declaration as context; PG15's forward declaration still has `pf` on one line.

**Resolution:**
- Added `#include "utils/guc.h"` after `#include "utils/builtins.h"`.
- Retained `#include "utils/uuid.h"`. Did not add `#include "varatt.h"`.
- Inserted `builtin_crypto_options[]`, the `builtin_crypto_enabled` global, and `_PG_init()` verbatim from the patch.
- Kept the existing `find_provider` forward declaration unchanged (parameter name `pf`, single line). The harmonization from `0faf7d933f62` is unrelated to this point-import and can be cherry-picked separately if desired.

### 2. `doc/src/sgml/pgcrypto.sgml` (content)

**Conflict reason:** Same trailing-context drift as on `924d89a` caused by [`78ee60ed84bb`](https://github.com/postgres/postgres/commit/78ee60ed84bb) ("Doc: add XML ID attributes to `<sectN>` and `<varlistentry>` tags.", PG16) adding `id="pgcrypto-notes"` to the trailing `<sect2>` that the patch uses as anchor context.

**Resolution:** Inserted the new "Configuration Parameters" `<sect2>` verbatim between the just-added "OpenSSL Support Functions" sect2 and the existing Notes sect2. Kept the new sect2's own anchor IDs (`id="pgcrypto-configuration-parameters"` and the inner `varlistentry id="..."`) — those were added by `035f99c` itself and are in scope. Did not import the `id="pgcrypto-notes"` rename — same scope-creep reason as on `924d89a`.

## Additional Change:

Added a forward declaration `void _PG_init(void);` near the top of `contrib/pgcrypto/pgcrypto.c` (just after `PG_MODULE_MAGIC`). Not part of upstream `035f99c`; required on PG15 because `fmgr.h` does not declare `_PG_init` automatically. Without it, gcc emits a `-Wmissing-prototypes` warning. Every other PG15 contrib module that defines `_PG_init` (`auth_delay`, `auto_explain`, `basic_archive`, etc.) carries the same one-line forward declaration. The automatic declaration of `_PG_init` in `fmgr.h` was added in a later PG version.